### PR TITLE
Move baseUrl to configuration

### DIFF
--- a/src/main/java/com/kuliginstepan/dadata/client/DadataClient.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/DadataClient.java
@@ -26,40 +26,28 @@ import com.kuliginstepan.dadata.client.domain.postal.PostalOffice;
 import com.kuliginstepan.dadata.client.domain.postal.PostalOfficeRequest;
 import com.kuliginstepan.dadata.client.exception.DadataException;
 import com.kuliginstepan.dadata.client.exception.ErrorDetails;
-import io.netty.handler.timeout.ReadTimeoutHandler;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
-import reactor.netty.tcp.TcpClient;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
-
-@RequiredArgsConstructor
+/**
+ * Should be build using {@link DadataClientBuilder}
+ */
 @Slf4j
 public class DadataClient {
 
-    private static final String BASE_API_URL = "https://suggestions.dadata.ru/suggestions/api/4_1/rs";
     private static final String SUGGESTION_PREFIX = "/suggest";
     private static final String GEOLOCATE_PREFIX = "/geolocate";
     private static final String FIND_BY_ID_PREFIX = "/findById";
-    private static final Duration DEFAULT_TIMEOUT = Duration.of(5, ChronoUnit.SECONDS);
 
-    private final String token;
-    private final Duration timeout;
+    private final WebClient webClient;
 
-    public DadataClient(String token) {
-        this.token = token;
-        timeout = DEFAULT_TIMEOUT;
+    protected DadataClient(WebClient webClient) {
+        this.webClient = webClient;
     }
 
     public Flux<Suggestion<Organization>> suggestOrganization(OrganizationRequest request) {
@@ -162,7 +150,7 @@ public class DadataClient {
 
     protected <T> Flux<Suggestion<T>> executeOperation(ParameterizedTypeReference<DadataResponse<T>> responseClass,
         BasicRequest request, String operationPrefix, String suggestionTypePrefix) {
-        return webClientBuilder().build()
+        return webClient
             .post().uri(operationPrefix + suggestionTypePrefix)
             .body(BodyInserters.fromObject(request))
             .exchange()
@@ -178,15 +166,5 @@ public class DadataClient {
             return response.bodyToMono(ErrorDetails.class)
                 .flatMap(error -> Mono.error(new DadataException(response.statusCode(), error)));
         }
-    }
-
-    private WebClient.Builder webClientBuilder() {
-        TcpClient timeoutClient = TcpClient.create()
-            .doOnConnected(
-                con -> con.addHandlerLast(new ReadTimeoutHandler(timeout.toMillis(), TimeUnit.MILLISECONDS)));
-        return WebClient.builder()
-            .clientConnector(new ReactorClientHttpConnector(HttpClient.from(timeoutClient)))
-            .baseUrl(BASE_API_URL)
-            .defaultHeader(HttpHeaders.AUTHORIZATION, "Token " + token);
     }
 }

--- a/src/main/java/com/kuliginstepan/dadata/client/DadataClientAutoConfiguration.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/DadataClientAutoConfiguration.java
@@ -12,10 +12,10 @@ public class DadataClientAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(DadataClient.class)
     public DadataClient dadataClient(DadataClientProperties clientProperties) {
-        if (clientProperties.getTimeout() == null) {
-            return new DadataClient(clientProperties.getToken());
-        } else {
-            return new DadataClient(clientProperties.getToken(), clientProperties.getTimeout());
-        }
+        return new DadataClientBuilder()
+                .token(clientProperties.getToken())
+                .timeout(clientProperties.getTimeout())
+                .baseUrl(clientProperties.getBaseUrl())
+                .build();
     }
 }

--- a/src/main/java/com/kuliginstepan/dadata/client/DadataClientBuilder.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/DadataClientBuilder.java
@@ -1,0 +1,62 @@
+package com.kuliginstepan.dadata.client;
+
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.TcpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Optional.ofNullable;
+
+public class DadataClientBuilder {
+
+    private WebClient webClient;
+    private Duration timeout;
+    private String token;
+    private String baseUrl;
+
+
+    public DadataClientBuilder webClient(WebClient webClient) {
+        this.webClient = webClient;
+        return this;
+    }
+
+    public DadataClientBuilder timeout(Duration timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    public DadataClientBuilder token(String token) {
+        this.token = token;
+        return this;
+    }
+
+    public DadataClientBuilder baseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+        return this;
+    }
+
+    public DadataClient build() {
+        if (webClient != null) {
+            return new DadataClient(webClient);
+        }
+        if (token == null) {
+            throw new IllegalArgumentException("Token or WebClient is needed to construct DadataClient");
+        }
+        DadataClientProperties defaultProps = new DadataClientProperties();
+        TcpClient timeoutClient = TcpClient.create()
+                .doOnConnected(
+                        con -> con.addHandlerLast(new ReadTimeoutHandler(ofNullable(this.timeout).orElse(defaultProps.getTimeout()).toMillis(), TimeUnit.MILLISECONDS)));
+        WebClient client = WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.from(timeoutClient)))
+                .baseUrl(ofNullable(this.baseUrl).orElse(defaultProps.getBaseUrl()))
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Token " + token)
+                .build();
+        return new DadataClient(client);
+    }
+
+}

--- a/src/main/java/com/kuliginstepan/dadata/client/DadataClientProperties.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/DadataClientProperties.java
@@ -1,12 +1,19 @@
 package com.kuliginstepan.dadata.client;
 
-import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 @ConfigurationProperties(prefix = "dadata.client")
 @Data
 public class DadataClientProperties {
+
+    /**
+     * Dadata base url
+     */
+    private String baseUrl = "https://suggestions.dadata.ru/suggestions/api/4_1/rs";
 
     /**
      * Dadata API token
@@ -14,7 +21,7 @@ public class DadataClientProperties {
     private String token;
 
     /**
-     * Request timeout
+     * Request timeout. Default - 5 seconds
      */
-    private Duration timeout;
+    private Duration timeout = Duration.of(5, ChronoUnit.SECONDS);
 }

--- a/src/test/java/com/kuliginstepan/dadata/client/DadataClientTest.java
+++ b/src/test/java/com/kuliginstepan/dadata/client/DadataClientTest.java
@@ -9,7 +9,7 @@ public class DadataClientTest {
 
     @Test(expected = DadataException.class)
     public void clientWithBadTokenTest() {
-        DadataClient client = new DadataClient("123456");
+        DadataClient client = new DadataClientBuilder().token("123456").build();
         client.findAddressById("").block();
     }
 
@@ -17,4 +17,5 @@ public class DadataClientTest {
     public void notSupportedOperationTest() {
         TestUtils.CLIENT.findById(new FioSuggestion(), new BasicRequest("test")).block();
     }
+
 }

--- a/src/test/java/com/kuliginstepan/dadata/client/DadataClientWithUrlAutoConfigurationTest.java
+++ b/src/test/java/com/kuliginstepan/dadata/client/DadataClientWithUrlAutoConfigurationTest.java
@@ -1,0 +1,21 @@
+package com.kuliginstepan.dadata.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"dadata.client.token=d0a06c568347cb09905d9a0fe9009380eb6b25d3", "dadata.client.baseUrl=http://fake-url"})
+public class DadataClientWithUrlAutoConfigurationTest {
+
+    @Autowired
+    DadataClient client;
+
+    @Test(expected = Exception.class)
+    public void shouldFailWithBadBaseUrl() {
+        client.findAddressById("").block();
+    }
+
+}

--- a/src/test/java/com/kuliginstepan/dadata/client/DadataClientWithWebClientTest.java
+++ b/src/test/java/com/kuliginstepan/dadata/client/DadataClientWithWebClientTest.java
@@ -1,0 +1,32 @@
+package com.kuliginstepan.dadata.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Import(DadataClientWithWebClientTest.TestConfig.class)
+public class DadataClientWithWebClientTest {
+
+    public static class TestConfig {
+        @Bean
+        public DadataClient client() {
+            return new DadataClientBuilder().webClient(WebClient.builder().build()).build();
+        }
+    }
+
+    @Autowired
+    DadataClient client;
+
+    @Test
+    public void contextLoadsWhenOnlyWebClientSpecified() {
+
+    }
+
+}

--- a/src/test/java/com/kuliginstepan/dadata/client/DadataClientWithoutTokenTest.java
+++ b/src/test/java/com/kuliginstepan/dadata/client/DadataClientWithoutTokenTest.java
@@ -1,0 +1,13 @@
+package com.kuliginstepan.dadata.client;
+
+import org.junit.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.SpringApplication;
+
+public class DadataClientWithoutTokenTest {
+
+    @Test(expected = BeanCreationException.class)
+    public void contextStartFailsIfNoTokenSupplied() {
+        SpringApplication.run(TestSpringBootApplication.class);
+    }
+}

--- a/src/test/java/com/kuliginstepan/dadata/client/TestUtils.java
+++ b/src/test/java/com/kuliginstepan/dadata/client/TestUtils.java
@@ -1,16 +1,17 @@
 package com.kuliginstepan.dadata.client;
 
 import com.kuliginstepan.dadata.client.domain.Suggestion;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestUtils {
 
-    public static final DadataClient CLIENT = new DadataClient("d0a06c568347cb09905d9a0fe9009380eb6b25d3");
+    public static final DadataClient CLIENT = new DadataClientBuilder().token("d0a06c568347cb09905d9a0fe9009380eb6b25d3").build();
 
     public static <T, R> List<T> getDistinctList(Function<Suggestion<R>, T> mapper, List<Suggestion<R>> suggestions) {
         return suggestions.stream()


### PR DESCRIPTION
Moving baseUrl to configuration, so that client can support standalone dadata deploys + some refactoring