### PR TITLE
Fix class type for email field in organization

### DIFF
--- a/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Organization.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Organization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.kuliginstepan.dadata.client.domain.AdditionalProps;
 import com.kuliginstepan.dadata.client.domain.Suggestion;
 import com.kuliginstepan.dadata.client.domain.address.Address;
+import com.kuliginstepan.dadata.client.domain.email.Email;
 import com.kuliginstepan.dadata.client.json.LocalDateDeserializer;
 import java.time.LocalDate;
 import java.util.List;
@@ -65,7 +66,7 @@ public class Organization extends AdditionalProps {
     List<License> licenses;
 
     List<String> phones;
-    List<String> emails;
+    List<Suggestion<Email>> emails;
 
 
 }

--- a/src/test/java/com/kuliginstepan/dadata/client/OrganizationSuggestionTest.java
+++ b/src/test/java/com/kuliginstepan/dadata/client/OrganizationSuggestionTest.java
@@ -123,12 +123,12 @@ public class OrganizationSuggestionTest {
     public void rangingSuggestOrganizationTest() {
         List<Suggestion<Organization>> suggestions = CLIENT
             .suggestOrganization(
-                OrganizationRequestBuilder.create("ип муромова").locationBoost("56").build()).collectList()
+                OrganizationRequestBuilder.create("ип муромова").locationBoost("63").build()).collectList()
             .block();
 
         assertNotNull(suggestions);
         assertFalse(suggestions.isEmpty());
-        assertTrue(suggestions.get(0).getData().getAddress().getData().getKladrId().startsWith("56"));
+        assertTrue(suggestions.get(0).getData().getAddress().getData().getKladrId().startsWith("63"));
     }
 
     @Test


### PR DESCRIPTION
Исправление ошибки возникающей в результате неуспешной десериализации поля data.emails[ ]. Ошибка возникает при поиске Организации и ИП.
JSON decoding error: Cannot deserialize instance of java.lang.Stringout of START_OBJECT token; nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance ofjava.lang.String out of START_OBJECT token at [Source: (io.netty.buffer.ByteBufInputStream); line: 1, column: 5388] (through reference chain: com.kuliginstepan.dadata.client.domain.DadataResponse["suggestions"]->java.util.ArrayList[0]->com.kuliginstepan.dadata.client.domain.Suggestion["data"]->com.kuliginstepan.dadata.client.domain.organization.Organization["emails"]->java.util.ArrayList[0])