### PR TITLE
Add a class type for phone field in organization

### DIFF
--- a/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Organization.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Organization.java
@@ -65,7 +65,7 @@ public class Organization extends AdditionalProps {
     Documents documents;
     List<License> licenses;
 
-    List<String> phones;
+    List<Suggestion<Phone>> phones;
     List<Suggestion<Email>> emails;
 
 

--- a/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Phone.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Phone.java
@@ -1,0 +1,37 @@
+package com.kuliginstepan.dadata.client.domain.organization;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.kuliginstepan.dadata.client.domain.AdditionalProps;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+/**
+ * @see <a href="https://dadata.ru/api/clean/phone/">Dadata phone object</a>
+ */
+
+@Value
+@Builder
+@EqualsAndHashCode(callSuper = true)
+public class Phone extends AdditionalProps {
+
+    String source;
+    String type;
+    @JsonAlias("phone")
+    String phoneNumber;
+    @JsonAlias("country_code")
+    String countryCode;
+    @JsonAlias("city_code")
+    String cityCode;
+    String number;
+    String extension;
+    String provider;
+    String country;
+    String region;
+    String city;
+    String timezone;
+    @JsonAlias("qc_conflict")
+    String qcConflict;
+    String qc;
+
+}

--- a/src/test/resources/organization.json
+++ b/src/test/resources/organization.json
@@ -257,7 +257,28 @@
             "qc": "0"
         }
     },
-    "phones": null,
+    "phones": [
+        {
+            "value":"+7 846 2316014",
+            "unrestricted_value":"+7 846 2316014",
+            "data":{
+                "source": "раб 846)231.60.14 *139",
+                "type": "Стационарный",
+                "phone": "+7 846 231-60-14 доб. 139",
+                "country_code": "7",
+                "city_code": "846",
+                "number": "2316014",
+                "extension": "139",
+                "provider": "ООО \"СИПАУТНЭТ\"",
+                "country": "Россия",
+                "region": "Самарская область",
+                "city": "Самара",
+                "timezone": "UTC+4",
+                "qc_conflict": 0,
+                "qc": 0
+            }
+        }
+    ],
     "emails": null,
     "ogrn_date": 1035763200000,
     "okved_type": "2014",


### PR DESCRIPTION
Исправление ошибки возникающей в результате неуспешной десериализации поля data.phones[ ]. Ошибка возникает при поиске Организации и ИП.

распознаваемый массив:
`            "phones":[
               {
                  "value":"+7 35361 23340",
                  "unrestricted_value":"+7 35361 23340",
                  "data":{
                     "contact":null,
                     "source":"(35361) 2-33-40",
                     "qc":"0",
                     "type":"Стационарный",
                     "number":"23340",
                     "extension":null,
                     "provider":"ПАО \"Ростелеком\"",
                     "country":null,
                     "region":"Оренбургская область",
                     "city":null,
                     "timezone":"UTC+5",
                     "country_code":"7",
                     "city_code":"35361",
                     "qc_conflict":null
                  }
               }
            ]`

ошибка:
`JSON decoding error: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token; nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token
 at [Source: (io.netty.buffer.ByteBufInputStream); line: 1, column: 9492] (through reference chain: com.kuliginstepan.dadata.client.domain.DadataResponse["suggestions"]->java.util.ArrayList[0]->com.kuliginstepan.dadata.client.domain.Suggestion["data"]->com.kuliginstepan.dadata.client.domain.organization.Organization["phones"]->java.util.ArrayList[0])`