### PR TITLE
Connection pool

### DIFF
--- a/src/main/java/com/kuliginstepan/dadata/client/DadataClientBuilder.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/DadataClientBuilder.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.DefaultSslContextSpec;
 import reactor.netty.transport.ProxyProvider;
 
@@ -60,7 +61,15 @@ public class DadataClientBuilder {
     }
 
     private HttpClient buildHttpClient() {
-        HttpClient httpClient = HttpClient.create()
+        ConnectionProvider connectionProvider = ConnectionProvider.builder("dadata-pool")
+                .maxConnections(clientProperties.getMaxConnections())
+                .pendingAcquireTimeout(clientProperties.getPendingAcquireTimeout())
+                .maxIdleTime(clientProperties.getMaxIdleTime())
+                .maxLifeTime(clientProperties.getMaxLifeTime())
+                .evictInBackground(clientProperties.getEvictInBackground())
+                .build();
+
+        HttpClient httpClient = HttpClient.create(connectionProvider)
             .doOnConnected(con -> con.addHandlerLast(
                 new ReadTimeoutHandler(clientProperties.getTimeout().toMillis(),
                     TimeUnit.MILLISECONDS)));

--- a/src/main/java/com/kuliginstepan/dadata/client/DadataClientProperties.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/DadataClientProperties.java
@@ -66,4 +66,35 @@ public class DadataClientProperties {
      * SSL verification option
      */
     private boolean verifySsl = true;
+
+    /**
+     * Максимальное количество соединений в пуле.
+     * Рекомендуется устанавливать не более 50, чтобы не превысить 60 новых соединений в минуту.
+     * По умолчанию 30.
+     */
+    private int maxConnections = 30;
+
+    /**
+     * Время ожидания свободного соединения из пула, если все заняты.
+     * По умолчанию 30 секунд.
+     */
+    private Duration pendingAcquireTimeout = Duration.ofSeconds(30);
+
+    /**
+     * Максимальное время простоя соединения в пуле (после этого оно закрывается).
+     * По умолчанию 60 секунд.
+     */
+    private Duration maxIdleTime = Duration.ofSeconds(60);
+
+    /**
+     * Максимальное время жизни соединения (с момента создания).
+     * По умолчанию 60 секунд.
+     */
+    private Duration maxLifeTime = Duration.ofSeconds(60);
+
+    /**
+     * Интервал фоновой очистки пула от простаивающих соединений.
+     * По умолчанию 30 секунд.
+     */
+    private Duration evictInBackground = Duration.ofSeconds(30);
 }

--- a/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Finance.java
+++ b/src/main/java/com/kuliginstepan/dadata/client/domain/organization/Finance.java
@@ -26,7 +26,8 @@ public class Finance {
         SRP,
         USN,
         ENVD_ESHN,
-        USN_ENVD
+        USN_ENVD,
+        AUSN
     }
 
 }


### PR DESCRIPTION
Используем connection pool. 
У dadata есть ограничение Максимальная частота создания [новых соединений] — 60 в минуту с одного IP-адреса.